### PR TITLE
generate speech as required and allow stop

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -16,37 +16,51 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 from mycroft import MycroftSkill, intent_file_handler
+from mycroft.audio import wait_while_speaking
 
 
 class Count(MycroftSkill):
     def __init__(self):
         MycroftSkill.__init__(self)
+        self.stop_requested = False
 
     @intent_file_handler('count.intent')
     def handle_count(self, message):
+        self.stop_requested = False
         try:
             number = int(message.data.get("number"))
             response = {'number': message.data.get("number")}
             self.speak_dialog("count_start", data=response)
             for i in range(1, number+1, +1):
+                if self.stop_requested:
+                    break
                 self.speak(str(i) + " .")
-            self.speak_dialog("count_stop")
-            pass
+                wait_while_speaking()
+            if not self.stop_requested:
+                self.speak_dialog("count_stop")
         except:
             self.speak_dialog("count_error")
 
     @intent_file_handler('countdown.intent')
     def handle_countdown_intent(self, message):
+        self.stop_requested = False
         try:
             number = int(message.data.get("number"))
             response = {'number': message.data.get("number")}
             self.speak_dialog("countdown_start", data=response)
             for i in range(number, 0, -1):
+                if self.stop_requested:
+                    break
                 self.speak(str(i) + " .")
-            self.speak_dialog("countdown_stop")
-            pass
+                wait_while_speaking()
+            if not self.stop_requested:
+                self.speak_dialog("countdown_stop")
         except:
             self.speak_dialog("count_error")
+
+    def stop(self):
+        self.stop_requested = True
+
 
 
 def create_skill():


### PR DESCRIPTION
Hey Andlo,

This got raised in a separate issue ([mycroft-core #2638](https://github.com/MycroftAI/mycroft-core/issues/2638)) so wanted to flag it with you. 

If you ask to count to a larger number then say "stop" the Count Skill continues counting and the numbers start to get out of order. It seemed easier to create a PR, so here it is :)

This waits until each number is finished being spoken before sending the next speech command.
It also adds a custom stop method and checks if a stop has been requested before each number is spoken.