### PR TITLE
Correct Swedish translation

### DIFF
--- a/vocab/sv-se/count.intent
+++ b/vocab/sv-se/count.intent
@@ -1,1 +1,1 @@
-Ränka till {number}
+Räkna till {number}


### PR DESCRIPTION
The word for "count" ("räkna") was accidentally mistyped as "ränka".